### PR TITLE
Handle container environments

### DIFF
--- a/setup_tailscale_proxmox.sh
+++ b/setup_tailscale_proxmox.sh
@@ -10,7 +10,57 @@ log() {
 
 # Function to check if a service exists and is active
 service_exists_and_active() {
-    systemctl is-active --quiet "$1"
+    if [ "$SYSTEMD_AVAILABLE" -eq 1 ]; then
+        systemctl is-active --quiet "$1"
+    else
+        return 1
+    fi
+}
+
+# Function to reset DNS to public resolvers
+fix_dns_settings() {
+    log "Resetting DNS settings to public resolvers..."
+    if [ -f /etc/resolv.conf ]; then
+        cp /etc/resolv.conf "/etc/resolv.conf.bak.$(date +%F_%T)"
+        cat <<EOF >/etc/resolv.conf
+nameserver 1.1.1.1
+nameserver 8.8.8.8
+EOF
+        log "DNS settings updated."
+    else
+        log "Unable to find /etc/resolv.conf. Skipping DNS reset."
+    fi
+}
+
+# Function to verify internet connectivity and DNS resolution
+check_internet_connectivity() {
+    log "Checking internet connectivity..."
+    if ! ping -c 1 -W 3 1.1.1.1 >/dev/null 2>&1; then
+        log "Unable to reach the internet."
+        read -r -p "Attempt to reset DNS settings? (y/n): " fix_net
+        if [ "$fix_net" = "y" ] || [ "$fix_net" = "Y" ]; then
+            fix_dns_settings
+        else
+            log "Please verify your network connection and try again."
+        fi
+        exit 1
+    fi
+
+    if ! ping -c 1 -W 3 tailscale.com >/dev/null 2>&1; then
+        log "DNS resolution failed. Old Tailscale settings may be interfering."
+        read -r -p "Reset DNS settings to public resolvers? (y/n): " fix_dns
+        if [ "$fix_dns" = "y" ] || [ "$fix_dns" = "Y" ]; then
+            fix_dns_settings
+            if ! ping -c 1 -W 3 tailscale.com >/dev/null 2>&1; then
+                log "DNS still failing after reset. Please check your network manually."
+                exit 1
+            fi
+        else
+            log "Please check your DNS configuration before continuing."
+            exit 1
+        fi
+    fi
+    log "Internet connectivity looks good."
 }
 
 # Check if running as root
@@ -19,7 +69,36 @@ if [ "$EUID" -ne 0 ]; then
     exit 1
 fi
 
+# Path to the certificate renewal helper script
+RENEW_SCRIPT="/usr/local/bin/renew_tailscale_cert.sh"
+
+# Remove old renewal script and cron entry if they exist
+if [ -f "$RENEW_SCRIPT" ]; then
+    log "Old renewal script detected. Removing it."
+    rm -f "$RENEW_SCRIPT"
+    crontab -l 2>/dev/null | grep -v "$RENEW_SCRIPT" | crontab -
+fi
+
+CONTAINER_TYPE="host"
+if command -v systemd-detect-virt >/dev/null; then
+    ct=$(systemd-detect-virt --container || true)
+    if [ "$ct" != "none" ] && [ -n "$ct" ]; then
+        CONTAINER_TYPE="$ct"
+        log "Detected container environment: $CONTAINER_TYPE"
+    fi
+fi
+
+if command -v systemctl >/dev/null && [ -d /run/systemd/system ]; then
+    SYSTEMD_AVAILABLE=1
+else
+    SYSTEMD_AVAILABLE=0
+    log "Warning: systemctl not available. Service restarts will be skipped."
+fi
+
 log "Starting Tailscale installation and HTTPS configuration for Proxmox."
+
+# Ensure network connectivity before proceeding
+check_internet_connectivity
 
 # Update package lists
 log "Updating package lists..."
@@ -42,14 +121,14 @@ else
 fi
 
 # Prompt for hostname
-read -p "Enter the desired hostname for your Proxmox server (e.g., prox): " TS_HOSTNAME
+read -r -p "Enter the desired hostname for your Proxmox server (e.g., prox): " TS_HOSTNAME
 
 # Start Tailscale and prompt for authentication
 log "Starting Tailscale with hostname '$TS_HOSTNAME'..."
 tailscale up --hostname="$TS_HOSTNAME"
 
 log "Please authenticate your Proxmox server in the Tailscale web interface."
-read -p "After authentication, press Enter to continue..."
+read -r -p "After authentication, press Enter to continue..."
 
 # Add a timeout for Tailscale connection
 TIMEOUT=300
@@ -75,12 +154,12 @@ TS_DOMAIN=$(tailscale status --json | jq -r '.Self.DNSName' | sed "s/$TS_HOSTNAM
 
 if [ -z "$TS_DOMAIN" ] || [[ "$TS_DOMAIN" == "null" ]]; then
     log "Unable to detect Tailscale domain."
-    read -p "Please enter your Tailscale domain (e.g., example.ts.net): " TS_DOMAIN
+    read -r -p "Please enter your Tailscale domain (e.g., example.ts.net): " TS_DOMAIN
 else
     log "Detected Tailscale domain: $TS_DOMAIN"
-    read -p "Is this correct? (y/n): " confirm_domain
+    read -r -p "Is this correct? (y/n): " confirm_domain
     if [ "$confirm_domain" != "y" ] && [ "$confirm_domain" != "Y" ]; then
-        read -p "Please enter your Tailscale domain (e.g., example.ts.net): " TS_DOMAIN
+        read -r -p "Please enter your Tailscale domain (e.g., example.ts.net): " TS_DOMAIN
     fi
 fi
 
@@ -126,6 +205,19 @@ NODE_NAME=$(hostname)
 PVE_CERT_DIR="/etc/pve/nodes/$NODE_NAME"
 PBS_CERT_DIR="/etc/proxmox-backup"
 
+# Detect whether this system is running Proxmox VE or Proxmox Backup Server
+if [ -f "/etc/pve/pve.cfg" ]; then
+    SYSTEM_TYPE="PVE"
+    log "Detected Proxmox VE system."
+elif [ -f "/etc/proxmox-backup/proxmox-backup.cfg" ]; then
+    SYSTEM_TYPE="PBS"
+    log "Detected Proxmox Backup Server system."
+else
+    SYSTEM_TYPE="UNKNOWN"
+    log "Warning: This doesn't appear to be a Proxmox VE or Proxmox Backup Server system."
+    log "The script will continue, but some Proxmox-specific operations may fail."
+fi
+
 # Backup existing certificates
 log "Backing up existing Proxmox certificates..."
 if [ -f "$PVE_CERT_DIR/pveproxy-ssl.pem" ]; then
@@ -159,55 +251,45 @@ if [ "$SYSTEM_TYPE" = "PBS" ]; then
     cp "$cert_hostname.key" "$PBS_CERT_DIR/proxy-key.pem"
 fi
 
-# Check if this is a Proxmox VE or Proxmox Backup Server system
-if [ -f "/etc/pve/pve.cfg" ]; then
-    SYSTEM_TYPE="PVE"
-    log "Detected Proxmox VE system."
-elif [ -f "/etc/proxmox-backup/proxmox-backup.cfg" ]; then
-    SYSTEM_TYPE="PBS"
-    log "Detected Proxmox Backup Server system."
-else
-    SYSTEM_TYPE="UNKNOWN"
-    log "Warning: This doesn't appear to be a Proxmox VE or Proxmox Backup Server system."
-    log "The script will continue, but some Proxmox-specific operations may fail."
-fi
-
 # Restart appropriate service based on the system type
 log "Attempting to restart appropriate service..."
-case $SYSTEM_TYPE in
-    "PVE")
-        if service_exists_and_active "pveproxy.service"; then
-            if ! systemctl restart pveproxy.service; then
-                log "Warning: Failed to restart pveproxy.service. You may need to restart it manually."
+if [ "$SYSTEMD_AVAILABLE" -eq 1 ]; then
+    case $SYSTEM_TYPE in
+        "PVE")
+            if service_exists_and_active "pveproxy.service"; then
+                if ! systemctl restart pveproxy.service; then
+                    log "Warning: Failed to restart pveproxy.service. You may need to restart it manually."
+                else
+                    log "Successfully restarted pveproxy.service."
+                fi
             else
-                log "Successfully restarted pveproxy.service."
+                log "Warning: pveproxy.service not found or not active."
             fi
-        else
-            log "Warning: pveproxy.service not found or not active."
-        fi
-        ;;
-    "PBS")
-        if service_exists_and_active "proxmox-backup-proxy.service"; then
-            if ! systemctl restart proxmox-backup-proxy.service; then
-                log "Warning: Failed to restart proxmox-backup-proxy.service. You may need to restart it manually."
+            ;;
+        "PBS")
+            if service_exists_and_active "proxmox-backup-proxy.service"; then
+                if ! systemctl restart proxmox-backup-proxy.service; then
+                    log "Warning: Failed to restart proxmox-backup-proxy.service. You may need to restart it manually."
+                else
+                    log "Successfully restarted proxmox-backup-proxy.service."
+                fi
             else
-                log "Successfully restarted proxmox-backup-proxy.service."
+                log "Warning: proxmox-backup-proxy.service not found or not active."
             fi
-        else
-            log "Warning: proxmox-backup-proxy.service not found or not active."
-        fi
-        ;;
-    *)
-        log "No Proxmox-specific service found to restart."
-        log "You may need to manually configure your web server to use the new certificates."
-        ;;
-esac
+            ;;
+        *)
+            log "No Proxmox-specific service found to restart."
+            log "You may need to manually configure your web server to use the new certificates."
+            ;;
+    esac
+else
+    log "systemctl not available; skipping service restarts."
+fi
 
 # Set up automatic certificate renewal
 log "Setting up automatic certificate renewal."
 
-# Renewal script path
-RENEW_SCRIPT="/usr/local/bin/renew_tailscale_cert.sh"
+# Renewal script path already defined earlier
 
 # Create renewal script with error handling
 cat <<EOF > "$RENEW_SCRIPT"
@@ -219,25 +301,36 @@ NODE_NAME=\$(hostname)
 PVE_CERT_DIR="/etc/pve/nodes/\$NODE_NAME"
 PBS_CERT_DIR="/etc/proxmox-backup"
 
+# Detect systemd availability
+if command -v systemctl >/dev/null && [ -d /run/systemd/system ]; then
+    SYSTEMD_AVAILABLE=1
+else
+    SYSTEMD_AVAILABLE=0
+fi
+
 # Obtain new certificate
-if ! tailscale cert $cert_hostname; then
+if ! tailscale cert "$cert_hostname"; then
     echo "Failed to renew certificate"
     exit 1
 fi
 
 # Install new certificate
-cp $cert_hostname.crt $PVE_CERT_DIR/pveproxy-ssl.pem
-cp $cert_hostname.key $PVE_CERT_DIR/pveproxy-ssl.key
+cp "$cert_hostname.crt" "$PVE_CERT_DIR/pveproxy-ssl.pem"
+cp "$cert_hostname.key" "$PVE_CERT_DIR/pveproxy-ssl.key"
 
 # Restart Proxmox services
-systemctl restart pveproxy.service
-systemctl restart pvedaemon.service
+if [ "\$SYSTEMD_AVAILABLE" -eq 1 ]; then
+    systemctl restart pveproxy.service
+    systemctl restart pvedaemon.service
+fi
 
 # Handle PBS if installed
 if [ -f "/etc/proxmox-backup/proxmox-backup.cfg" ]; then
-    cp $cert_hostname.crt $PBS_CERT_DIR/proxy-cert.pem
-    cp $cert_hostname.key $PBS_CERT_DIR/proxy-key.pem
-    systemctl restart proxmox-backup-proxy.service
+    cp "$cert_hostname.crt" "$PBS_CERT_DIR/proxy-cert.pem"
+    cp "$cert_hostname.key" "$PBS_CERT_DIR/proxy-key.pem"
+    if [ "\$SYSTEMD_AVAILABLE" -eq 1 ]; then
+        systemctl restart proxmox-backup-proxy.service
+    fi
 fi
 EOF
 


### PR DESCRIPTION
## Summary
- detect container type using `systemd-detect-virt`
- skip service restarts when systemd is unavailable
- allow renewal script to function without systemd
- remove any previous renewal script installation
- verify internet connectivity before starting
- ask to reset DNS settings when network checks fail

## Testing
- `shellcheck setup_tailscale_proxmox.sh`


------
https://chatgpt.com/codex/tasks/task_e_6850663165a4832490261ed10df022cd